### PR TITLE
remove detectron2 from package tests (#979)

### DIFF
--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -76,10 +76,6 @@ jobs:
         run: >
           pip install deepsparse
 
-      - name: Install Detectron2(0.6)
-        run: >
-          python -m pip install detectron2 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.10/index.html
-
       - name: Install Transformers(4.35.0)
         run: >
           pip install transformers==4.35.0


### PR DESCRIPTION
Keeping repository up to date with parent.
They have removed the testing job for detectron2 from their CI/CD pipeline.

Our resources are unaffected.