### PR TITLE
Sahi remove logging

### DIFF
--- a/sahi/models/detectron2.py
+++ b/sahi/models/detectron2.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2020.
 
-import logging
 from typing import List, Optional
 
 import numpy as np
@@ -11,7 +10,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.cv import get_bbox_from_bool_mask
 from sahi.utils.import_utils import check_requirements
 
-logger = logging.getLogger(__name__)
 
 
 class Detectron2DetectionModel(DetectionModel):
@@ -57,7 +55,6 @@ class Detectron2DetectionModel(DetectionModel):
                     str(ind): category_name for ind, category_name in enumerate(self.category_names)
                 }
             except Exception as e:
-                logger.warning(e)
                 # https://detectron2.readthedocs.io/en/latest/tutorials/datasets.html#update-the-config-for-new-datasets
                 if cfg.MODEL.META_ARCHITECTURE == "RetinaNet":
                     num_categories = cfg.MODEL.RETINANET.NUM_CLASSES

--- a/sahi/models/huggingface.py
+++ b/sahi/models/huggingface.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon and Devrim Cavusoglu, 2022.
 
-import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -12,7 +11,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.import_utils import check_requirements, ensure_package_minimum_version
 
-logger = logging.getLogger(__name__)
 
 
 class HuggingfaceDetectionModel(DetectionModel):

--- a/sahi/models/mmdet.py
+++ b/sahi/models/mmdet.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2020.
 
-import logging
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
@@ -11,8 +10,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.cv import get_bbox_from_bool_mask
 from sahi.utils.import_utils import check_requirements
-
-logger = logging.getLogger(__name__)
 
 
 try:
@@ -298,7 +295,6 @@ class MmdetDetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/torchvision.py
+++ b/sahi/models/torchvision.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon and Kadir Nar, 2021.
 
-import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -10,7 +9,6 @@ from sahi.models.base import DetectionModel
 from sahi.prediction import ObjectPrediction
 from sahi.utils.import_utils import check_requirements
 
-logger = logging.getLogger(__name__)
 
 
 class TorchVisionDetectionModel(DetectionModel):
@@ -40,12 +38,9 @@ class TorchVisionDetectionModel(DetectionModel):
         # complete params if not provided in config
         if not model_name:
             model_name = "fasterrcnn_resnet50_fpn"
-            logger.warning(f"model_name not provided in config, using default model_type: {model_name}'")
         if num_classes is None:
-            logger.warning("num_classes not provided in config, using default num_classes: 91")
             num_classes = 91
         if self.model_path is None:
-            logger.warning("model_path not provided in config, using pretrained weights and default num_classes: 91.")
             pretrained = True
             num_classes = 91
         else:

--- a/sahi/models/yolonas.py
+++ b/sahi/models/yolonas.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2020.
 
-import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -12,7 +11,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.import_utils import check_requirements
 
-logger = logging.getLogger(__name__)
 
 
 class YoloNasDetectionModel(DetectionModel):
@@ -175,7 +173,6 @@ class YoloNasDetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/yolov5.py
+++ b/sahi/models/yolov5.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2020.
 
-import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -11,7 +10,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.import_utils import check_package_minimum_version, check_requirements
 
-logger = logging.getLogger(__name__)
 
 
 class Yolov5DetectionModel(DetectionModel):
@@ -150,7 +148,6 @@ class Yolov5DetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/yolov5sparse.py
+++ b/sahi/models/yolov5sparse.py
@@ -3,7 +3,6 @@
 # Using YOLOv5 sparse models from Neural Magic using DeepSparse
 # https://neuralmagic.com/deepsparse
 
-import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -13,7 +12,6 @@ from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.import_utils import check_package_minimum_version, check_requirements
 
-logger = logging.getLogger(__name__)
 
 
 class Yolov5SparseDetectionModel(DetectionModel):
@@ -202,7 +200,6 @@ class Yolov5SparseDetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/yolov8.py
+++ b/sahi/models/yolov8.py
@@ -1,12 +1,10 @@
 # OBSS SAHI Tool
 # Code written by AnNT, 2023.
 
-import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-logger = logging.getLogger(__name__)
 
 from sahi.models.base import DetectionModel
 from sahi.prediction import ObjectPrediction
@@ -145,7 +143,6 @@ class Yolov8DetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/yolov8onnx.py
+++ b/sahi/models/yolov8onnx.py
@@ -8,8 +8,6 @@ import cv2
 import numpy as np
 import torch
 
-logger = logging.getLogger(__name__)
-
 from sahi.models.base import DetectionModel
 from sahi.prediction import ObjectPrediction
 from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
@@ -231,7 +229,6 @@ class Yolov8OnnxDetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/yolov8onnx.py
+++ b/sahi/models/yolov8onnx.py
@@ -1,8 +1,7 @@
 # OBSS SAHI Tool
 # Code written by Karl-Joan Alesma and Michael García, 2023.
 
-import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -23,6 +22,8 @@ class Yolov8OnnxDetectionModel(DetectionModel):
         Args:
             iou_threshold: float
                 IOU threshold for non-max supression, defaults to 0.7.
+                
+            input and output shape are redundant parameters to avoid implementing logic between TensorRT and ONNX versions
         """
         super().__init__(*args, **kwargs)
         self.iou_threshold = iou_threshold

--- a/sahi/models/yolov8onnx.py
+++ b/sahi/models/yolov8onnx.py
@@ -16,7 +16,9 @@ from sahi.utils.yolov8onnx import non_max_supression, xywh2xyxy
 
 
 class Yolov8OnnxDetectionModel(DetectionModel):
-    def __init__(self, *args, iou_threshold: float = 0.7, **kwargs):
+    def __init__(
+        self, *args, iou_threshold: float = 0.7, input_shape=[1, 3, 512, 416], output_shape=[1, 10, 4368], **kwargs
+    ):
         """
         Args:
             iou_threshold: float

--- a/sahi/models/yolov8trt.py
+++ b/sahi/models/yolov8trt.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, List, Optional, Tuple
 
 import cv2
@@ -16,7 +15,6 @@ from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
 from sahi.utils.import_utils import check_requirements
 from sahi.utils.yolov8trt import non_max_supression, xywh2xyxy
 
-logger = logging.Logger(__name__)
 
 class HostDeviceMem(object):
     def __init__(self, host_mem, device_mem):
@@ -93,7 +91,6 @@ class Yolov8TrtDetectionModel(DetectionModel):
             raise TypeError("Category mapping values are required")
     
     def allocate_buffers(self):
-        logger.debug(" Allocating buffers ...")
         inputs = None
         outputs = None
         bindings = []
@@ -106,9 +103,7 @@ class Yolov8TrtDetectionModel(DetectionModel):
         for binding in self.engine:
             binding_idx = self.engine.get_binding_index(binding)
             size = trt.volume(self.context.get_binding_shape(binding_idx))
-            logger.debug(f"Get binding shape {self.context.get_binding_shape(binding_idx)}")
             dtype = trt.nptype(self.engine.get_binding_dtype(binding))
-            logger.debug(f"Dtype : {dtype}")
 
             if self.engine.binding_is_input(binding):
                 host_mem = np.zeros(self.input_shape, np.float16)
@@ -289,7 +284,6 @@ class Yolov8TrtDetectionModel(DetectionModel):
 
                 # ignore invalid predictions
                 if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
-                    logger.warning(f"ignoring invalid prediction with bbox: {bbox}")
                     continue
 
                 object_prediction = ObjectPrediction(

--- a/sahi/models/yolov8trt.py
+++ b/sahi/models/yolov8trt.py
@@ -61,9 +61,7 @@ class Yolov8TrtDetectionModel(DetectionModel):
         """Detection model is initialized and set to self.model.
         """
 
-        try:
-            print(self.model_path)
-            
+        try:            
             trt.init_libnvinfer_plugins(None, "")  
 
             with open(self.model_path, 'rb') as f:

--- a/sahi/postprocess/combine.py
+++ b/sahi/postprocess/combine.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2021.
 
-import logging
 from typing import List
 
 import torch
@@ -10,7 +9,6 @@ from sahi.postprocess.utils import ObjectPredictionList, has_match, merge_object
 from sahi.prediction import ObjectPrediction
 from sahi.utils.import_utils import check_requirements
 
-logger = logging.getLogger(__name__)
 
 
 def batched_nms(predictions: torch.tensor, match_metric: str = "IOU", match_threshold: float = 0.5):
@@ -583,7 +581,6 @@ class LSNMSPostprocess(PostprocessPredictions):
         if self.match_metric == "IOS":
             NotImplementedError(f"match_metric={self.match_metric} is not supported for LSNMSPostprocess")
 
-        logger.warning("LSNMSPostprocess is experimental and not recommended to use.")
 
         object_prediction_list = ObjectPredictionList(object_predictions)
         object_predictions_as_numpy = object_prediction_list.tonumpy()

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -1,7 +1,6 @@
 # OBSS SAHI Tool
 # Code written by Fatih C Akyon, 2020.
 
-import logging
 import os
 import time
 from typing import List, Optional
@@ -51,7 +50,6 @@ POSTPROCESS_NAME_TO_CLASS = {
 LOW_MODEL_CONFIDENCE = 0.1
 
 
-logger = logging.getLogger(__name__)
 
 
 def get_prediction(
@@ -464,9 +462,6 @@ def predict(
 
     # auto postprocess type
     if not force_postprocess_type and model_confidence_threshold < LOW_MODEL_CONFIDENCE and postprocess_type != "NMS":
-        logger.warning(
-            f"Switching postprocess type/metric to NMS/IOU since confidence threshold is low ({model_confidence_threshold})."
-        )
         postprocess_type = "NMS"
         postprocess_match_metric = "IOU"
 

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -2,7 +2,6 @@
 # Code written by Fatih C Akyon, 2020.
 
 import concurrent.futures
-import logging
 import os
 import time
 from pathlib import Path
@@ -18,7 +17,7 @@ from sahi.utils.coco import Coco, CocoAnnotation, CocoImage, create_coco_dict
 from sahi.utils.cv import IMAGE_EXTENSIONS_LOSSLESS, IMAGE_EXTENSIONS_LOSSY, read_image_as_pil
 from sahi.utils.file import load_json, save_json
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("RoC")
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
     datefmt="%m/%d/%Y %H:%M:%S",

--- a/sahi/slicing.py
+++ b/sahi/slicing.py
@@ -2,6 +2,7 @@
 # Code written by Fatih C Akyon, 2020.
 
 import concurrent.futures
+import logging
 import os
 import time
 from pathlib import Path
@@ -17,12 +18,8 @@ from sahi.utils.coco import Coco, CocoAnnotation, CocoImage, create_coco_dict
 from sahi.utils.cv import IMAGE_EXTENSIONS_LOSSLESS, IMAGE_EXTENSIONS_LOSSY, read_image_as_pil
 from sahi.utils.file import load_json, save_json
 
-logger = logging.getLogger("RoC")
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-    level=os.environ.get("LOGLEVEL", "INFO").upper(),
-)
+logger = logging.getLogger(__name__)
+
 
 MAX_WORKERS = 20
 

--- a/sahi/utils/coco.py
+++ b/sahi/utils/coco.py
@@ -3,7 +3,6 @@
 # Modified by Sinan O Altinuc, 2020.
 
 import copy
-import logging
 import os
 import threading
 from collections import Counter, defaultdict
@@ -21,12 +20,7 @@ from tqdm import tqdm
 from sahi.utils.file import is_colab, load_json, save_json
 from sahi.utils.shapely import ShapelyAnnotation, box, get_shapely_multipolygon
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-    level=os.environ.get("LOGLEVEL", "INFO").upper(),
-)
+
 
 
 class CocoCategory:
@@ -132,9 +126,7 @@ class CocoAnnotation:
         """
         if annotation_dict.__contains__("segmentation") and not isinstance(annotation_dict["segmentation"], list):
             has_rle_segmentation = True
-            logger.warning(
-                f"Segmentation annotation for id {annotation_dict['id']} is skipped since RLE segmentation format is not supported."
-            )
+         
         else:
             has_rle_segmentation = False
 
@@ -1600,10 +1592,8 @@ def export_yolov5_images_and_txts_from_coco_object(
         disable_symlink: bool
             If True, symlinks are not created. Instead images are copied.
     """
-    logger.info("generating image symlinks and annotation files for yolov5..."),
     # symlink is not supported in colab
     if is_colab() and not disable_symlink:
-        logger.warning("symlink is not supported in colab, disabling it...")
         disable_symlink = True
     if mp:
         with Pool(processes=48) as pool:

--- a/sahi/utils/import_utils.py
+++ b/sahi/utils/import_utils.py
@@ -1,15 +1,8 @@
 import importlib.util
-import logging
 import os
 
 # adapted from https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-    level=os.environ.get("LOGLEVEL", "INFO").upper(),
-)
 
 
 def get_package_info(package_name: str, verbose: bool = True):
@@ -29,7 +22,6 @@ def get_package_info(package_name: str, verbose: bool = True):
             except AttributeError:
                 _version = "unknown"
         if verbose:
-            logger.info(f"{package_name} version {_version} is available.")
     else:
         _version = "N/A"
 
@@ -75,11 +67,7 @@ def check_package_minimum_version(package_name: str, minimum_version: str, verbo
 
     _is_available, _version = get_package_info(package_name, verbose=verbose)
     if _is_available:
-        if _version == "unknown":
-            logger.warning(
-                f"Could not determine version of {package_name}. Assuming version {minimum_version} is compatible."
-            )
-        else:
+        if _version != "unknown":
             if version.parse(_version) < version.parse(minimum_version):
                 return False
     return True
@@ -93,11 +81,8 @@ def ensure_package_minimum_version(package_name: str, minimum_version: str, verb
 
     _is_available, _version = get_package_info(package_name, verbose=verbose)
     if _is_available:
-        if _version == "unknown":
-            logger.warning(
-                f"Could not determine version of {package_name}. Assuming version {minimum_version} is compatible."
-            )
-        else:
+        if _version != "unknown":
+   
             if version.parse(_version) < version.parse(minimum_version):
                 raise ImportError(
                     f"Please upgrade {package_name} to version {minimum_version} or higher to use this module."

--- a/sahi/utils/import_utils.py
+++ b/sahi/utils/import_utils.py
@@ -21,7 +21,6 @@ def get_package_info(package_name: str, verbose: bool = True):
                 _version = importlib.import_module(package_name).__version__
             except AttributeError:
                 _version = "unknown"
-        if verbose:
     else:
         _version = "N/A"
 

--- a/sahi/utils/yolov8onnx.py
+++ b/sahi/utils/yolov8onnx.py
@@ -53,7 +53,6 @@ def non_max_supression(boxes: np.ndarray, scores: np.ndarray, iou_threshold: flo
         # Remove boxes with IoU over the threshold
         keep_indices = np.where(ious < iou_threshold)[0]
 
-        # print(keep_indices.shape, sorted_indices.shape)
         sorted_indices = sorted_indices[keep_indices + 1]
 
     return keep_boxes

--- a/sahi/utils/yolov8trt.py
+++ b/sahi/utils/yolov8trt.py
@@ -47,7 +47,6 @@ def non_max_supression(boxes: np.ndarray, scores: np.ndarray, iou_threshold: flo
         # Remove boxes with IoU over the threshold
         keep_indices = np.where(ious < iou_threshold)[0]
 
-        # print(keep_indices.shape, sorted_indices.shape)
         sorted_indices = sorted_indices[keep_indices + 1]
 
     return keep_boxes

--- a/tests/test_yolov8trt.py
+++ b/tests/test_yolov8trt.py
@@ -1,10 +1,8 @@
 import unittest
-import logging
 
 import cv2
 import tensorrt as trt
 
-logger = logging.getLogger(__name__)
 TRT_LOGGER = trt.Logger()
 
 from sahi.utils.cv import read_image


### PR DESCRIPTION
To avoid logging duplication due to __name__ propagation the logging has been removed where possible.
In one instance it remains due to SAHI's `verboselog` method but only for conditional initialisation and it is not utilised as `verbose=0`.

Using this now give us normal log outputs with no duplication or formatting inconsistencies for [roc_tracking_cnn](https://github.com/provizio/roc_tracking_cnn)
